### PR TITLE
Reproducible pipeline that retains gene coordinates for adding conservation

### DIFF
--- a/code/filtering/filtering.py
+++ b/code/filtering/filtering.py
@@ -15,8 +15,12 @@ def filter_and_create_table(data):
         'noncodingRNA_fam': filtered_data['noncodingRNA_fam'],
         'feature': filtered_data['feature'],
         'test': filtered_data['chr.g'].apply(lambda x: True if x == '1' else False),
-        'label': '1'
-    }, columns=['gene', 'noncodingRNA', 'noncodingRNA_fam', 'feature', 'test', 'label'])
+        'label': '1',
+        'chr': filtered_data['chr.g'],
+        'start': filtered_data['start.g'],
+        'end': filtered_data['end.g'],
+        'strand': filtered_data['strand.g']
+    }, columns=['gene', 'noncodingRNA', 'noncodingRNA_fam', 'feature', 'test', 'label', 'chr', 'start', 'end', 'strand'])
 
     return filtered_table
 

--- a/code/make_neg_sets/make_neg_sets.py
+++ b/code/make_neg_sets/make_neg_sets.py
@@ -14,7 +14,6 @@ def precompute_allowed_mirnas(positive_samples_df, min_allowed_distance):
         allowed_mirnas[mirna] = [other_mirna for other_mirna in unique_mirnas 
                                  if mirna != other_mirna and 
                                  levenshtein_distance(mirna, other_mirna) > min_allowed_distance]
-    
     return allowed_mirnas
 
 # Get unique pairs of noncodingRNA sequence (seqm) and family
@@ -63,8 +62,7 @@ def generate_negative_samples(block, neg_ratio, unique_seqm_fam_pairs_dict, allo
     pos_mirnas = block['noncodingRNA'].unique().tolist()
     
     # Get the set of miRNAs that are allowed to be paired with this gene as negative examples
-    gene_allowed_mirnas = set.intersection(*[set(allowed_mirnas[mirna]) for mirna in pos_mirnas])
-    gene_allowed_mirnas = list(gene_allowed_mirnas)
+    gene_allowed_mirnas = sorted(set.intersection(*[set(allowed_mirnas[mirna]) for mirna in pos_mirnas])) # returns a sorted list for reproducibility
 
     # If neg_ratio is 'max', use all the negative examples possible for this gene
     if neg_ratio == 'max':

--- a/code/make_neg_sets/make_neg_sets.py
+++ b/code/make_neg_sets/make_neg_sets.py
@@ -85,10 +85,14 @@ def generate_negative_samples(block, neg_ratio, unique_seqm_fam_pairs_dict, allo
 
     feature = block['feature'].iloc[0]
     test = block['test'].iloc[0]
+    chromosome = block['chr'].iloc[0]
+    start = block['start'].iloc[0]
+    end = block['end'].iloc[0]
+    strand = block['strand'].iloc[0]
 
     # Construct the df rows for the negative examples
     negative_sample_rows = [
-        [gene, neg_mirna, unique_seqm_fam_pairs_dict[neg_mirna], feature, test, neg_label]
+        [gene, neg_mirna, unique_seqm_fam_pairs_dict[neg_mirna], feature, test, neg_label, chromosome, start, end, strand]
         for neg_mirna in n_negative_mirnas
     ]
 
@@ -122,7 +126,7 @@ def main():
 
     unsuccessful = 0 
 
-    inconsistent_blocks = pd.DataFrame(columns=['gene', 'noncodingRNA', 'noncodingRNA_fam', 'feature', 'test', 'label'])
+    inconsistent_blocks = pd.DataFrame(columns=['gene', 'noncodingRNA', 'noncodingRNA_fam', 'feature', 'test', 'label', 'chr', 'start', 'end', 'strand'])
 
     with open(args.ofile, 'a') as ofile:
         


### PR DESCRIPTION
Added chr, start, end, strand in pos and neg examples to final output. 

Made pipeline reproducible by sorting the set of gene_allowed_mirnas. 