### PR TITLE
Added Manakov concatenated HybriDetector output file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/*.tsv filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-data/
+
 results/

--- a/data/AGO2_eCLIP_Manakov2022_full_dataset.tsv
+++ b/data/AGO2_eCLIP_Manakov2022_full_dataset.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00a838332fbcd99ceba0af1067161ccde6d7bb03bc9a0e539ae41dd5d1897998
+size 607249635


### PR DESCRIPTION
Added Manakov concatenated HybriDetector output file so we host it somewhere and it's publicly available. Stored using Git LFS as the file is 600MB. 